### PR TITLE
Add support for capturing Echidna's output

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ pages](https://github.com/crytic/echidna/wiki).
 | `crytic-args`        | Additional arguments to use in crytic-compile for the compilation of the contract to test.
 | `solc-args`          | Additional arguments to use in solc for the compilation of the contract to test.
 | `solc-version`       | Version of the Solidity compiler to use.
+| `output-file`        | Capture echidna-test's output into a file. The path must be relative to the repository root.
 | `negate-exit-status` | Apply logical NOT to echidna-test's exit status (for testing the action).
 
 ## Outputs
 
-This action has no outputs.
+| Key           | Description
+|---------------|------------
+| `output-file` | If produced, the file containing echidna-test's output, relative to the repository root.
 
 ## Examples
 

--- a/action.yml
+++ b/action.yml
@@ -54,9 +54,16 @@ inputs:
   solc-version:
     description: "Version of the Solidity compiler to use"
     required: false
+  output-file:
+    description: "Capture echidna's output into this file. The path must be relative to the repository root."
+    required: false
   negate-exit-status:
     description: "Apply logical NOT to echidna-test's exit status (for testing the action)"
     required: false
+
+outputs:
+  output-file:
+    description: "If produced, the file containing echidna-test's output, relative to the repository root."
 
 runs:
   using: "docker"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,6 +40,13 @@ fi
 
 echo "${CMD[@]}" >&2
 
+OUTPUT_FILE="$(get 'INPUT_OUTPUT-FILE')"
+if [[ -n "$OUTPUT_FILE" ]]; then
+    echo "::set-output name=output-file::$OUTPUT_FILE"
+    # tee stdout to $OUTPUT_FILE to capture echidna's output
+    exec > >(tee "$OUTPUT_FILE")
+fi
+
 if [[ -n "$(get 'INPUT_NEGATE-EXIT-STATUS')" ]]; then
     ! "${CMD[@]}"
 else


### PR DESCRIPTION
This adds a new input (and output) property named `output-file` which can redirect Echidna's output into a file. This is useful if checking the tool's output is required, or when using e.g. the JSON output format.