### PR TITLE
Update action parameters to support Echidna v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pages](https://github.com/crytic/echidna/wiki).
 | `config`             | Config file (CLI arguments override config options).
 | `format`             | Output format: json, text, none. Disables interactive UI.
 | `corpus-dir`         | Directory to store corpus and coverage data.
-| `check-asserts`      | Check asserts in the code.
+| `test-mode`          | Type of tests to be performed: property, assertion, overflow, optimization, exploration.
 | `multi-abi`          | Use multi-abi mode of testing.
 | `test-limit`         | Number of sequences of transactions to generate during testing.
 | `shrink-limit`       | Number of tries to attempt to shrink a failing sequence of transactions.

--- a/action.yml
+++ b/action.yml
@@ -22,8 +22,8 @@ inputs:
   corpus-dir:
     description: "Directory to store corpus and coverage data"
     required: false
-  check-asserts:
-    description: "Check asserts in the code"
+  test-mode:
+    description: "Type of tests to be performed"
     required: false
   multi-abi:
     description: "Use multi-abi mode of testing"
@@ -94,7 +94,7 @@ runs:
         INPUT_CONFIG: ${{ inputs.config }}
         INPUT_FORMAT: ${{ inputs.format }}
         INPUT_CORPUS-DIR: ${{ inputs.corpus-dir }}
-        INPUT_CHECK-ASSERTS: ${{ inputs.check-asserts }}
+        INPUT_TEST-MODE: ${{ inputs.test-mode }}
         INPUT_MULTI-ABI: ${{ inputs.multi-abi }}
         INPUT_TEST-LIMIT: ${{ inputs.test-limit }}
         INPUT_SHRINK-LIMIT: ${{ inputs.shrink-limit }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,10 +4,10 @@ set -eu
 
 export PYTHONPATH=/root/.local/lib/python3.6/site-packages
 
-OPTIONS="contract config format corpus-dir test-limit shrink-limit seq-len \
-contract-addr deployer sender seed crytic-args solc-args"
+OPTIONS="contract config format corpus-dir test-limit test-mode shrink-limit \
+seq-len contract-addr deployer sender seed crytic-args solc-args"
 
-SWITCHES="check-asserts multi-abi"
+SWITCHES="multi-abi"
 
 # smoelius: `get` works for non-standard variable names like `INPUT_CORPUS-DIR`.
 get() {


### PR DESCRIPTION
This replaces `checkAsserts` with `testMode` and updates documentation.

Fixes: #5 