### PR TITLE
Add support for changing working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ pages](https://github.com/crytic/echidna/wiki).
 | `output-file`        | Capture echidna-test's output into a file. The path must be relative to the repository root.
 | `echidna-version`    | Version of the Echidna Docker image to use.
 | `negate-exit-status` | Apply logical NOT to echidna-test's exit status (for testing the action).
+| `echidna-workdir`    | Path to run echidna-test from. Note that `files` and `config` are relative to this path.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,9 @@ inputs:
     description: "Version of the Echidna Docker image to use"
     required: false
     default: latest
+  echidna-workdir:
+    description: "Path to run echidna-test from. Note that `files` and `config` are relative to this path"
+    required: false
 
 outputs:
   output-file:
@@ -108,3 +111,4 @@ runs:
         INPUT_SOLC-VERSION: ${{ inputs.solc-version }}
         INPUT_OUTPUT-FILE: ${{ inputs.output-file }}
         INPUT_NEGATE-EXIT-STATUS: ${{ inputs.negate-exit-status }}
+        INPUT_ECHIDNA-WORKDIR: ${{ inputs.echidna-workdir }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,6 +47,11 @@ if [[ -n "$OUTPUT_FILE" ]]; then
     exec > >(tee "$OUTPUT_FILE")
 fi
 
+WORKDIR="$(get 'INPUT_ECHIDNA-WORKDIR')"
+if [[ -n "$WORKDIR" ]]; then
+    cd "$WORKDIR"
+fi
+
 if [[ -n "$(get 'INPUT_NEGATE-EXIT-STATUS')" ]]; then
     ! "${CMD[@]}"
 else


### PR DESCRIPTION
This is useful when testing standalone .sol files which may need Echidna to
be run from a specific folder in the solution.