### PR TITLE
Create symlink from host-path to container-path to enhance compatibility

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,12 @@ inputs:
   echidna-workdir:
     description: "Path to run echidna-test from. Note that `files` and `config` are relative to this path"
     required: false
+  internal-github-workspace:
+    # Do not set manually. This is a hacky way to pass the host workspace to inside the action
+    # This is used to improve compatibility when using ignore-compile.
+    # GitHub rewrites the argument if it is passed directly, to we use toJSON to "transform"
+    # it and avoid the remapping done by GitHub Actions.
+    default: ${{ toJSON(github.workspace) }}
 
 outputs:
   output-file:
@@ -112,3 +118,4 @@ runs:
         INPUT_OUTPUT-FILE: ${{ inputs.output-file }}
         INPUT_NEGATE-EXIT-STATUS: ${{ inputs.negate-exit-status }}
         INPUT_ECHIDNA-WORKDIR: ${{ inputs.echidna-workdir }}
+        INPUT_INTERNAL-GITHUB-WORKSPACE: ${{ inputs.internal-github-workspace }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,18 @@ get() {
     env | sed -n "s/^$1=\(.*\)/\1/;T;p"
 }
 
+compatibility_link()
+{
+    HOST_GITHUB_WORKSPACE="$(get INPUT_INTERNAL-GITHUB-WORKSPACE | tr -d \")"
+    if [[ -d "$GITHUB_WORKSPACE" ]]; then
+        mkdir -p "$(dirname "$HOST_GITHUB_WORKSPACE")"
+        ln -s "$GITHUB_WORKSPACE" "$HOST_GITHUB_WORKSPACE"
+        echo "[-] Applied compatibility link: $HOST_GITHUB_WORKSPACE -> $GITHUB_WORKSPACE"
+    fi
+}
+
+compatibility_link
+
 CMD=(echidna-test "$INPUT_FILES")
 
 for OPTION in $OPTIONS; do

--- a/launch.sh
+++ b/launch.sh
@@ -3,7 +3,7 @@
 IMAGE=$1
 INPUTS=$(env | cut -f1 -d= | grep '^INPUT_')
 
-CMD=(docker run --rm -v "$PWD:/github/workspace" --workdir /github/workspace)
+CMD=(docker run --rm -v "$PWD:/github/workspace" --workdir /github/workspace -e GITHUB_WORKSPACE=/github/workspace)
 
 for VARNAME in $INPUTS; do
     CMD+=(-e "$VARNAME")


### PR DESCRIPTION
If a project is built outside of the container and the build artifacts contain absolute paths, this can cause issues as the folder "moves" between build and analysis time due to the Echidna action running inside a Docker container. This creates a symlink from the old path to the new one to try and avoid any issues that might arise from this path change.