### PR TITLE
feat: add rpc configs `rpc-block` and `rpc-url` to inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ pages](https://github.com/crytic/echidna/wiki).
 | `test-mode`          | Type of tests to be performed: property, assertion, overflow, optimization, exploration.
 | `multi-abi`          | Use multi-abi mode of testing.
 | `test-limit`         | Number of sequences of transactions to generate during testing.
+| `rpc-block`          | Block number to use when fetching over RPC.
+| `rpc-url`            | Fetch contracts over a RPC URL.
 | `shrink-limit`       | Number of tries to attempt to shrink a failing sequence of transactions.
 | `seq-len`            | Number of transactions to generate during testing.
 | `contract-addr`      | Address to deploy the contract to test.

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ name: "echidna-action"
 description: "Run Echidna, the smart contract fuzzer"
 
 branding:
-  icon: 'shield'  
+  icon: 'shield'
   color: 'red'
 
 inputs:
@@ -30,6 +30,12 @@ inputs:
     required: false
   test-limit:
     description: "Number of sequences of transactions to generate during testing"
+    required: false
+  rpc-block:
+    description: "Block number to use when fetching over RPC"
+    required: false
+  rpc-url:
+    description: "Fetch contracts over a RPC URL"
     required: false
   shrink-limit:
     description: "Number of tries to attempt to shrink a failing sequence of transactions"
@@ -106,6 +112,8 @@ runs:
         INPUT_TEST-MODE: ${{ inputs.test-mode }}
         INPUT_MULTI-ABI: ${{ inputs.multi-abi }}
         INPUT_TEST-LIMIT: ${{ inputs.test-limit }}
+        INPUT_RPC-BLOCK: ${{ inputs.rpc-block }}
+        INPUT_RPC-URL: ${{ inputs.rpc-url }}
         INPUT_SHRINK-LIMIT: ${{ inputs.shrink-limit }}
         INPUT_SEQ-LEN: ${{ inputs.seq-len }}
         INPUT_CONTRACT-ADDR: ${{ inputs.contract-addr }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,8 @@
 
 set -eu
 
-OPTIONS="contract config format corpus-dir test-limit test-mode shrink-limit \
-seq-len contract-addr deployer sender seed crytic-args solc-args"
+OPTIONS="contract config format corpus-dir test-limit test-mode rpc-block rpc-url \
+shrink-limit seq-len contract-addr deployer sender seed crytic-args solc-args"
 
 SWITCHES="multi-abi"
 


### PR DESCRIPTION
[Since rpc configs were added to CLI](https://github.com/crytic/echidna/pull/1194), once a new release is made to latest tag, we can add these to github inputs as well.

Closes #19
